### PR TITLE
feat: create WalletInfo component to display wallet details

### DIFF
--- a/Claude/ISSUES_GITHUB.md
+++ b/Claude/ISSUES_GITHUB.md
@@ -5,7 +5,7 @@
 
 ---
 
-## Issues CLOSED (18)
+## Issues CLOSED (19)
 
 ### Recherche & Documentation (#1-7)
 - **#1** : [RESEARCH] Backend Architecture Choice
@@ -16,12 +16,13 @@
 - **#6** : [TESTING] Testing Strategy Definition
 - **#7** : [DEVOPS] Deployment & CI/CD Pipeline
 
-### Développement (#18-22)
+### Développement (#18-24)
 - **#18** : Setup: Créer fichier de données avec les 42 fondateurs
 - **#19** : Frontend: Setup wagmi + RainbowKit pour connexion wallet
 - **#20** : Frontend: Créer composant ConnectButton avec RainbowKit
 - **#21** : Frontend: Gérer la vérification du réseau Base Mainnet
 - **#22** : Backend: Créer endpoint de vérification whitelist
+- **#23** : Frontend: Créer composant NotEligible (message d'erreur)
 
 ### Setup Additionnel (#77-81)
 - **#77** : Frontend: Setup Tailwind CSS v4
@@ -32,13 +33,12 @@
 
 ---
 
-## Issues OPEN (56)
+## Issues OPEN (55)
 
 ### Optionnel (#8)
 - **#8** : [OPTIONAL] Founders Data Enrichment
 
-### Frontend - Connexion & Wallet (#23-24)
-- **#23** : Frontend: Créer composant NotEligible (message d'erreur)
+### Frontend - Connexion & Wallet (#24)
 - **#24** : Frontend: Afficher les informations du wallet connecté
 
 ### Frontend - Propositions (#25-34)
@@ -195,5 +195,6 @@
 - **PR #84** - Configuration variables d'environnement (issue #79)
 - **PR #85** - Setup React Router pour navigation (issue #80)
 - **PR #86** - Installation et configuration INTUITION SDK (issue #81)
+- **PR #87** - Composant NotEligible (issue #23)
 
 **Note** : Le Layout créé (#78) est un composant wrapper basique. L'issue #49 (Layout + routing) concerne le layout complet avec navigation et React Router.

--- a/apps/web/src/components/WalletInfo.tsx
+++ b/apps/web/src/components/WalletInfo.tsx
@@ -1,0 +1,50 @@
+import { useAccount, useBalance, useDisconnect } from 'wagmi';
+
+export function WalletInfo() {
+  const { address, isConnected } = useAccount();
+  const { data: balance } = useBalance({ address });
+  const { disconnect } = useDisconnect();
+
+  if (!isConnected || !address) {
+    return null;
+  }
+
+  // Format address for display (0x1234...5678)
+  const formatAddress = (addr: string) => {
+    return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+  };
+
+  // Format balance for display
+  const formatBalance = () => {
+    if (!balance) return '0';
+    const value = parseFloat(balance.formatted);
+    return value.toFixed(4);
+  };
+
+  return (
+    <div className="glass-card p-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col">
+          <span className="text-white/50 text-xs mb-1">Wallet connecté</span>
+          <span className="text-white font-mono text-sm">
+            {formatAddress(address)}
+          </span>
+        </div>
+
+        <div className="flex flex-col items-end">
+          <span className="text-white/50 text-xs mb-1">Balance</span>
+          <span className="text-white font-medium">
+            {formatBalance()} {balance?.symbol || 'ETH'}
+          </span>
+        </div>
+
+        <button
+          onClick={() => disconnect()}
+          className="glass-button text-sm px-3 py-1.5"
+        >
+          Déconnecter
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Create WalletInfo component to display connected wallet information
- Show formatted wallet address (0x1234...5678)
- Display ETH balance on Base network
- Add disconnect button with glass-card styling

## Component Features

- Uses wagmi hooks: `useAccount`, `useBalance`, `useDisconnect`
- Auto-formats address for readability
- Shows balance with 4 decimal precision
- Responsive glass-card design

## Test plan

- [ ] Vérifier que `pnpm build` passe sans erreur
- [ ] Tester l'affichage avec wallet connecté
- [ ] Vérifier que la balance s'affiche correctement
- [ ] Tester le bouton disconnect

Closes #24