### PR TITLE
feat: add 3 suggested predicates to ProposalModal

### DIFF
--- a/apps/web/src/components/ProposalModal.tsx
+++ b/apps/web/src/components/ProposalModal.tsx
@@ -27,6 +27,9 @@ const DEFAULT_PREDICATES = [
   'has totem',
   'is symbolized by',
   'is associated with',
+  'embodies',
+  'channels',
+  'resonates with',
 ];
 
 export function ProposalModal({


### PR DESCRIPTION
## Description

Ajoute 3 prédicats manquants à la liste des suggestions dans le ProposalModal pour aligner avec la documentation.

## Changements

Ajout de 3 prédicats suggérés :
- `embodies` (incarne)
- `channels` (canalise)
- `resonates with` (résonne avec)

Liste complète maintenant (7 prédicats) :
- is represented by
- has totem
- is symbolized by
- is associated with
- **embodies** ✨ NEW
- **channels** ✨ NEW
- **resonates with** ✨ NEW

## Contexte

Ces prédicats sont documentés dans :
- [Vote_Aggregation_Research.md](https://github.com/Dev-Moulin/intuition-founders-totem/blob/main/Claude/03_TECHNOLOGIES/Vote_Aggregation_Research.md)
- [IMPLEMENTATION_STATUS.md](https://github.com/Dev-Moulin/intuition-founders-totem/blob/main/Claude/03_TECHNOLOGIES/IMPLEMENTATION_STATUS.md#pr%C3%A9dicats-par-d%C3%A9faut)

## Note importante

Les utilisateurs restent **libres de créer n'importe quel prédicat** personnalisé. Ces suggestions sont des exemples, pas une liste exhaustive.

## Type de changement

- [x] Enhancement (ajout de fonctionnalité)
- [x] Documentation alignment

## Checklist

- [x] Code testé localement
- [x] Pas de breaking changes
- [x] Documentation à jour